### PR TITLE
TinyGo Comparable fix

### DIFF
--- a/map.go
+++ b/map.go
@@ -63,15 +63,6 @@ func (_map *Map[K, V]) Clear() {
 	_map.m.Clear()
 }
 
-func (_map *Map[K, V]) Swap(key K, value V) (V, error) {
-	v, ok := _map.m.Swap(key, value)
-	if !ok {
-		return _map.zero(), KeyNotFound
-	}
-
-	return v.(V), nil
-}
-
 func (_map *Map[K, V]) LoadOrStore(key K, value V) (V, error) {
 	v, ok := _map.m.LoadOrStore(key, value)
 	if !ok {
@@ -88,14 +79,6 @@ func (_map *Map[K, V]) LoadAndDelete(key K) (V, error) {
 	}
 
 	return v.(V), nil
-}
-
-func (_map *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
-	return _map.m.CompareAndSwap(key, old, new)
-}
-
-func (_map *Map[K, V]) CompareAndDelete(key K, value V) bool {
-	return _map.m.CompareAndDelete(key, value)
 }
 
 func (_map *Map[K, V]) Range(fn func(K, V) bool) {

--- a/map_cmp.go
+++ b/map_cmp.go
@@ -1,0 +1,39 @@
+/*
+ *     Enhanced `sync.Map` implementation for Go.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+//go:build !tinygo
+
+package Map
+
+func (_map *Map[K, V]) Swap(key K, value V) (V, error) {
+	v, ok := _map.m.Swap(key, value)
+	if !ok {
+		return _map.zero(), KeyNotFound
+	}
+
+	return v.(V), nil
+}
+
+func (_map *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	return _map.m.CompareAndSwap(key, old, new)
+}
+
+func (_map *Map[K, V]) CompareAndDelete(key K, value V) bool {
+	return _map.m.CompareAndDelete(key, value)
+}

--- a/map_tinygo.go
+++ b/map_tinygo.go
@@ -1,0 +1,62 @@
+/*
+ *     Enhanced `sync.Map` implementation for Go.
+ *     Copyright (C) 2024  Dviih
+ *
+ *     This program is free software: you can redistribute it and/or modify
+ *     it under the terms of the GNU Affero General Public License as published
+ *     by the Free Software Foundation, either version 3 of the License, or
+ *     (at your option) any later version.
+ *
+ *     This program is distributed in the hope that it will be useful,
+ *     but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *     GNU Affero General Public License for more details.
+ *
+ *     You should have received a copy of the GNU Affero General Public License
+ *     along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ */
+
+//go:build tinygo
+
+package Map
+
+import "reflect"
+
+func (_map *Map[K, V]) Swap(key K, value V) (V, error) {
+	p, err := _map.Load(key)
+	if err != nil {
+		p = _map.zero()
+	}
+
+	_map.Store(key, value)
+	return p, nil
+}
+
+func (_map *Map[K, V]) CompareAndSwap(key K, old, new V) bool {
+	c, err := _map.Load(key)
+	if err != nil {
+		return false
+	}
+
+	if reflect.DeepEqual(old, c) {
+		return false
+	}
+
+	_map.Store(key, new)
+	return true
+}
+
+func (_map *Map[K, V]) CompareAndDelete(key K, value V) bool {
+	c, err := _map.Load(key)
+	if err != nil {
+		return false
+	}
+
+	if reflect.DeepEqual(value, c) {
+		return false
+	}
+
+	_map.Delete(key)
+	return true
+}


### PR DESCRIPTION
This pull request fixes some issue related to TinyGo's implementation as it misses some methods of sync.Map, this pull request fixes it by implementing it with special build tags.
The affected methods were: `Swap`, `CompareAndSwap` and `CompareAndDelete`.